### PR TITLE
Fixed console errs when unbound keypress event fires

### DIFF
--- a/src/components/synth/synth.js
+++ b/src/components/synth/synth.js
@@ -324,7 +324,7 @@ function controller(patchService, sequenceService, userService, $window) {
             fired[$event.keyCode] = true;
             $event.preventDefault();
             const note = this.notes.find(n => n.keyCode === $event.keyCode);
-            this.noteOn(note.note);
+            if(note) this.noteOn(note.note);
         }
     };
 
@@ -334,7 +334,7 @@ function controller(patchService, sequenceService, userService, $window) {
         $event.preventDefault();
         //following line works
         const note = this.notes.find(n => n.keyCode === $event.keyCode);
-        this.noteOff(note.note);
+        if(note) this.noteOff(note.note);
     };
 
     this.keyDownHandler = this.keyDown.bind(this);


### PR DESCRIPTION
We had a lot of conspicuous console log errors when you'd press keys that weren't bound to notes -- I think this takes care of it!